### PR TITLE
Add syntax for compute shader workgroup size

### DIFF
--- a/Spec/WSL.g4
+++ b/Spec/WSL.g4
@@ -57,6 +57,8 @@ THREAD: 'thread';
 
 VERTEX: 'vertex';
 FRAGMENT: 'fragment';
+COMPUTE: 'compute';
+NUMTHREADS: 'numthreads';
 
 NATIVE: 'native';
 RESTRICTED: 'restricted';
@@ -125,7 +127,7 @@ enumMember: Identifier ('=' constexpr)? ;
 
 funcDef: RESTRICTED? funcDecl block;
 funcDecl
-    : (VERTEX | FRAGMENT) type Identifier parameters
+    : (VERTEX | FRAGMENT | ('[' NUMTHREADS '(' CoreDecimalIntLiteral ',' CoreDecimalIntLiteral ',' CoreDecimalIntLiteral ')' ']' COMPUTE)) type Identifier parameters
     | type (Identifier | OperatorName) parameters
     | OPERATOR type parameters ;
 // Note: the return type is moved in a different place for operator casts, as a hint that it plays a role in overload resolution. to bikeshed


### PR DESCRIPTION
For example: https://github.com/Microsoft/DirectX-Graphics-Samples/blob/8f68bf07dfd134df3b90e83a63535d053bae9a8a/Libraries/D3D12RaytracingFallback/src/FallbackLayerUnitTests/DynamicIndexTest.hlsl

[numthreads( 8, 8, 1 )]

https://docs.microsoft.com/en-us/windows/desktop/direct3dhlsl/d3d11-graphics-reference-sm5-attributes