### PR TITLE
Fixup package build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "git+https://github.com/gpuweb/WHLSL.git"
   },
   "scripts": {
-    "build": ". Scripts/build.sh",
+    "build": ". Scripts/build",
     "lint": "eslint --ext .js .",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
The build script does not have a .sh extension, although one is
specified in the package.json file. This CL fixes package.json to point
ot build instead of build.sh.