### PR TITLE
Simplify typeArguments grammar

### DIFF
--- a/Source/NameResolver.mjs
+++ b/Source/NameResolver.mjs
@@ -221,7 +221,7 @@ export default class NameResolver extends Visitor {
         let funcs = this._nameContext.get(Func, node.name);
         if (funcs)
             node.possibleOverloads = funcs;
-        else if (node.name != "operator cast"){
+        else {
             node.setCastData(new TypeRef(node.origin, node.name));
             node.possibleOverloads = this._nameContext.get(Func, "operator cast");
         }

--- a/Source/Parse.mjs
+++ b/Source/Parse.mjs
@@ -467,46 +467,25 @@ export function parse(program, origin, originKind, lineNumberOffset, text)
 
     function parseCallExpression()
     {
-        let parseArguments = function(origin, callName) {
-            let argumentList = [];
-            while (!test(")")) {
-                let argument = parsePossibleAssignment();
-                if (argument instanceof WSyntaxError)
-                    return argument;
-                argumentList.push(argument);
-                if (!tryConsume(","))
-                    break;
-            }
-            let maybeError = consume(")");
-            if (maybeError instanceof WSyntaxError)
-                return maybeError;
-            return new CallExpression(origin, callName, argumentList);
-        }
-
-        let name = backtrackingScope(() => {
-            let name = consumeKind("identifier");
-            if (name instanceof WSyntaxError)
-                return name;
-            let maybeError = consume("(");
-            if (maybeError instanceof WSyntaxError)
-                return maybeError;
+        let name = consumeKind("identifier");
+        if (name instanceof WSyntaxError)
             return name;
-        });
-
-        if (name) {
-            let result = parseArguments(name, name.text);
-            return result;
-        } else {
-            let returnType = parseType();
-            if (returnType instanceof WSyntaxError)
-                return returnType;
-            let maybeError = consume("(");
-            if (maybeError instanceof WSyntaxError)
-                return maybeError;
-            let result = parseArguments(returnType.origin, "operator cast");
-            result.setCastData(returnType);
-            return result;
+        let maybeError = consume("(");
+        if (maybeError instanceof WSyntaxError)
+            return maybeError;
+        let argumentList = [];
+        while (!test(")")) {
+            let argument = parsePossibleAssignment();
+            if (argument instanceof WSyntaxError)
+                return argument;
+            argumentList.push(argument);
+            if (!tryConsume(","))
+                break;
         }
+        maybeError = consume(")");
+        if (maybeError instanceof WSyntaxError)
+            return maybeError;
+        return new CallExpression(origin, name.text, argumentList);
     }
 
     function isCallExpression()

--- a/Source/Test.mjs
+++ b/Source/Test.mjs
@@ -3496,19 +3496,11 @@ tests.vectorTypeSyntax = function()
             vector<int,4> z = int4(3, 4, 5, 6);
             x = z;
             return x.w;
-        }
-
-        test bool vec2OperatorCast()
-        {
-            int2 x = vector<int,2>(1, 2);
-            vector<int, 2> y = int2(1, 2);
-            return x == y && x.x == 1 && x.y == 2 && y.x == 1 && y.y == 2;
         }`);
 
     checkInt(program, callFunction(program, "foo2", []), 4);
     checkInt(program, callFunction(program, "foo3", []), 5);
     checkInt(program, callFunction(program, "foo4", []), 6);
-    checkBool(program, callFunction(program, "vec2OperatorCast", []), true);
 
     program = doPrep(`
         typedef i = int;
@@ -3518,17 +3510,9 @@ tests.vectorTypeSyntax = function()
             vector<i, 2> z = int2(3, 4);
             x = z;
             return x.y;
-        }
-
-        test bool vec2OperatorCast()
-        {
-            int2 x = vector<i,2>(1, 2);
-            vector<i, 2> y = int2(1, 2);
-            return x == y && x.x == 1 && x.y == 2 && y.x == 1 && y.y == 2;
         }`);
 
     checkInt(program, callFunction(program, "foo2", []), 4);
-    checkBool(program, callFunction(program, "vec2OperatorCast", []), true);
 }
 
 tests.builtinVectors = function()
@@ -6101,26 +6085,6 @@ tests.casts = function()
         }
     `);
     checkInt(program, callFunction(program, "baz", [makeInt(program, 6)]), 13);
-    program = doPrep(`
-        struct Foo {
-            int x;
-        }
-        struct Bar {
-            int y;
-        }
-        operator thread Bar*(thread Foo* foo) {
-            Bar b;
-            b.y = (*foo).x + 8;
-            return &b;
-        }
-        test int baz(int z) {
-            Foo foo;
-            foo.x = z;
-            thread Bar* b = thread Bar*(&foo);
-            return (*b).y;
-        }
-    `);
-    checkInt(program, callFunction(program, "baz", [makeInt(program, 6)]), 14);
 }
 
 tests.atomics = function()

--- a/Spec/WHLSL.g4
+++ b/Spec/WHLSL.g4
@@ -154,11 +154,9 @@ typeSuffixNonAbbreviated: '*' addressSpace | '[]' addressSpace | '[' IntLiteral 
 // Note: in this formulation of typeSuffix*, we don't allow whitespace between the '[' and the ']' in '[]'. We easily could at the cost of a tiny more bit of lookahead. to bikeshed
 
 typeArguments
-    : '<' (typeArgument ',')* addressSpace? Identifier '<' (typeArgument (',' typeArgument)*)? '>>'
-    // Note: this first alternative is a horrible hack to deal with nested generics that end with '>>'. As far as I can tell it works fine, but requires arbitrary lookahead.
     | '<' typeArgument (',' typeArgument)* '>'
     | ('<' '>')? ;
-typeArgument: constexpr | type ;
+typeArgument: constexpr | Identifier ;
 
 /* 
  * Parser: Statements 
@@ -243,7 +241,7 @@ prefixOp: '++' | '--' | '+' | '-' | '~' | '!' | '&' | '@' | '*' ;
 possibleSuffix
     : callExpression limitedSuffixOperator*
     | term (limitedSuffixOperator | '++' | '--')* ;
-callExpression: Identifier typeArguments '(' (possibleTernaryConditional (',' possibleTernaryConditional)*)? ')';
+callExpression: Identifier '(' (possibleTernaryConditional (',' possibleTernaryConditional)*)? ')';
 term
     : literal
     | Identifier


### PR DESCRIPTION
We removed generics from the language, so our handling of typeArguments can be simplified.
Currently the reference compiler doesn't parse things like Texture2D<vector<float, 4>>.
This is okay because there is only a small list of well-known types that can have type arguments.
Instead, authors should say Texture2D<float4>.

Also, functions don't take type parameters any more, so function calls shouldn't have typeArguments.