### PR TITLE
Call expressions must be allowed as top-level statements in functions

### DIFF
--- a/Spec/WHLSL.g4
+++ b/Spec/WHLSL.g4
@@ -204,7 +204,8 @@ constexpression
 effectfulExpr: ((effAssignment ',')* effAssignment)? ; 
 effAssignment
     : possiblePrefix assignOperator possibleTernaryConditional
-    | effPrefix ;
+    | effPrefix
+    | callExpression ;
 assignOperator: '=' | '+=' | '-=' | '*=' | '/=' | '%=' | '^=' | '&=' | '|=' | '>>=' | '<<=' ;
 effPrefix
     : ('++' | '--') possiblePrefix


### PR DESCRIPTION
Currently, the following fails to parse:
```WHLSL
void foo() {
    int x;
    bar(&x);
}
```

The problem is that there is no `=`, `++`, or `--` in `bar(&x);`
This is because we limit top-level statements in functions to "effectful" statements.
We do this to eliminate ambiguity of the form `a * b`. This could either be a declaration
of a pointer named `b` or describing the computation of "multiply a times b". However,
because we have pointers, a function call is able to assign to a variable in the current
scope, so it needs to be considered an "effectful" statement.