### PR TITLE
Only describe the grammar that authors can actually use

### DIFF
--- a/Spec/WHLSL.g4
+++ b/Spec/WHLSL.g4
@@ -117,9 +117,7 @@ topLevelDecl
     | typeDef
     | structDef
     | enumDef
-    | funcDef
-    | nativeFuncDecl
-    | nativeTypeDecl;
+    | funcDef;
 
 typeDef: TYPEDEF Identifier '=' type ';' ;
 
@@ -141,9 +139,6 @@ parameters
     : '(' ')'
     | '(' parameter (',' parameter)* ')' ;
 parameter: Qualifier* type Identifier? (':' Semantic)?;
-
-nativeFuncDecl: RESTRICTED? NATIVE funcDecl ';' ;
-nativeTypeDecl: NATIVE TYPEDEF Identifier typeArguments ';' ;
 
 type
     : addressSpace Identifier typeArguments typeSuffixAbbreviated+


### PR DESCRIPTION
The "native" keyword should only be valid in the standard library.
The official WHLSL repository shouldn't include this dialect, and should
only include the grammar that authors can actually use. The form of the
standard library is an implementation detail of the compiler.