### PR TITLE
Add casts from booleans to number

### DIFF
--- a/Source/StandardLibrary.mjs
+++ b/Source/StandardLibrary.mjs
@@ -89,6 +89,13 @@ export let standardLibrary = (function() {
         }
         print();
 
+        for (let type of [`uchar`, `ushort`, `uint`, `char`, `short`, `int`, `half`, `float`]) {
+            print(`operator ${type}(bool x) {`);
+            print(`    return x ? 1 : 0;`);
+            print(`}`);
+        }
+        print();
+
         print(`native operator int(atomic_int);`);
         print(`native operator uint(atomic_uint);`);
         print();

--- a/Spec/source/Generate_Standard_Library.js
+++ b/Spec/source/Generate_Standard_Library.js
@@ -51,6 +51,13 @@ for (let type of [`uchar`, `ushort`, `uint`, `char`, `short`, `int`, `half`, `fl
 }
 print();
 
+for (let type of [`uchar`, `ushort`, `uint`, `char`, `short`, `int`, `half`, `float`]) {
+    print(`operator ${type}(bool x) {`);
+    print(`    return x ? 1 : 0;`);
+    print(`}`);
+}
+print();
+
 for (let addressSpace of [`device`, `threadgroup`]) {
     print(`native int load(${addressSpace} atomic_int*);`);
     print(`native uint load(${addressSpace} atomic_uint*);`);


### PR DESCRIPTION
This patch makes it so that we can cast from booleans to numbers. The conversion is to return 1 if the boolean is true, and zero if it is false.

This patch also adds a test for bool(NaN) == true.